### PR TITLE
Uses rounded down when dividing items of a layout

### DIFF
--- a/ListerTest/SceneDelegate.swift
+++ b/ListerTest/SceneDelegate.swift
@@ -12,7 +12,7 @@ import UIKit
 // 181.0 --> 181.0
 
 
-let cellSize = CGSize(width: UIScreen.main.bounds.width / 2 - 6, height: 200)
+let cellSize = CGSize(width: ((UIScreen.main.bounds.width / 2) - 6.0).rounded(.down), height: 200)
 
 class SceneDelegate: UIResponder, UIWindowSceneDelegate {
 


### PR DESCRIPTION

![image](https://user-images.githubusercontent.com/1733891/138109063-296f825e-0f15-4f76-9732-426252d5af7f.png)

https://developer.apple.com/documentation/uikit/views_and_controls/collection_views/layouts/customizing_collection_view_layouts